### PR TITLE
feat: Add .gitattributes to standardize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# .gitattributes file
+#
+# The .gitattributes file is a configuration file that allows customization of how Git handles files and directories within this
+# repository. It provides the ability to specify the line ending style for text files, identify which files are binary, and even
+# automatically collapse lengthy diffs, among other functionalities.
+
+# Auto-detect text files and perform LF normalization on line endings.
+* text=auto eol=lf
+
+# Ensure that Windows batch and CMD files always use CRLF for line endings.
+*.bat text eol=crlf
+*.cmd text eol=crlf


### PR DESCRIPTION
### Summary
Implemented a `.gitattributes` file to enforce consistent line ending standards across the project, ensuring `.cmd` and `.bat` files use CRLF, while all other text files use LF.

### Related Issues/PRs/Discussions
- Closes #3

### Background
The need for consistent line endings across various operating systems and text editors led to the creation of a `.gitattributes` file. This ensures that `.cmd` and `.bat` files function correctly on Windows by using CRLF, with LF for all other text files.

### Detailed Changes
- Created a `.gitattributes` file in the root of the repository.
- Configured the `.gitattributes` file to auto-detect text files and normalize LF line endings.
- Ensured `.bat` and `.cmd` files specifically use CRLF line endings.

### Pre-Merge Checklist
- [x] Verify the `.gitattributes` file works as expected across different environments.

### Testing
Local testing was conducted by committing `.bat`, `.cmd`, and `.txt` files to a branch and verifying the correct application of line endings.

### User Impact
This change is expected to be transparent to end-users but significantly improves developer experience by preventing line-ending related issues in a cross-platform development environment.

### Risk Assessment
Minimal risk; the changes are confined to repository configuration and have been tested locally.

### Areas for Review
- Reviewers should ensure the `.gitattributes` file's configurations are correctly applied to all relevant file types.
- Confirm that the implementation does not inadvertently affect binary files or other non-text file handling.

### Additional Context
N/A

### References
N/A