### PR TITLE
chore: Include Markdown files in repository statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,6 @@
 # Ensure that Windows batch and CMD files always use CRLF for line endings.
 *.bat text eol=crlf
 *.cmd text eol=crlf
+
+# Include Markdown files in repository language statistics.
+*.md linguist-detectable=true


### PR DESCRIPTION
### Summary
This pull request configures the repository to include Markdown files in its statistics, addressing Issue #9.

### Related Issues/PRs/Discussions
- Closes #9

### Background
The inclusion of Markdown files in the repository's statistics aims to provide a more accurate representation of the project's documentation and overall health.

### Detailed Changes
- Updated the `.gitattributes` file to mark Markdown files as `linguist-detectable=true`, ensuring they are included in the repository's language statistics.

### Pre-Merge Checklist
N/A

### Testing
Testing involved local verification of the `.gitattributes` file changes. Further validation will be conducted post-merge to assess the impact on the repository's statistics as displayed on GitHub.

### User Impact
This change is expected to have minimal direct impact on end-users but will enhance the visibility of documentation within the repository's statistics.

### Risk Assessment
The risk associated with this change is low, as it primarily affects the repository's metadata and presentation on GitHub without altering the functionality of the codebase.

### Areas for Review
- Reviewers are encouraged to verify the syntax and effectiveness of the `.gitattributes` modifications.

### Additional Context
N/A

### References
N/A