### PR TITLE
feat: Implement Dev Container Setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+# syntax=docker/dockerfile:1
+
+# Dockerfile for Dev Container
+#
+# This Dockerfile configures a Dev Container for the project.
+
+FROM mcr.microsoft.com/devcontainers/base:bookworm

--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -1,0 +1,11 @@
+# Docker Compose configuration for the Dev Container
+
+services:
+  main:
+    build:
+      context: ../
+      dockerfile: .devcontainer/Dockerfile
+    tty: true
+    stdin_open: true
+    volumes:
+      - ../:/workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+  "name": "General Template Dev Container",
+  // Using a Docker Compose file.
+  "dockerComposeFile": "./compose.yaml",
+  "service": "main",
+  "workspaceFolder": "/workspace",
+  "features": {},
+  "customizations": {
+    "vscode": {
+      "extensions": [
+      ]
+    }
+  },
+  "remoteUser": "vscode"
+}


### PR DESCRIPTION
### Summary
This PR introduces the setup for a Development Container, aiming to standardize the development environment across different machines, as addressed in issue #19.

### Related Issues/PRs/Discussions
- Closes #19

### Background
The motivation behind this PR is to mitigate the "works on my machine" problem by providing a consistent development environment through the use of a Dev Container. This setup facilitates development by ensuring that all team members work within the same environment, regardless of their local machine setup.

### Detailed Changes
- Added a `Dockerfile` that specifies Debian 12 Bookworm as the base image for the Dev Container.
- Created a `docker-compose.yaml` file to manage the Dev Container, defining the service `main` with necessary configurations.
- Configured `devcontainer.json` to integrate with VS Code, specifying settings such as the Docker Compose file, service, workspace folder, and remote user.

### Pre-Merge Checklist
- [x] Review the `Dockerfile` for any potential issues.
- [x] Ensure the `docker-compose.yaml` file is correctly set up.
- [x] Verify that `devcontainer.json` integrates smoothly with VS Code.

### Testing
The Dev Container was successfully launched and connected to via VS Code. The ability to edit files within the container was confirmed, ensuring the setup is functional for development purposes.

### User Impact
Developers will benefit from a streamlined setup process and a consistent development environment, reducing the time spent on environment setup and troubleshooting.

### Risk Assessment
The changes are confined to development environment configuration, presenting minimal risk to the existing codebase. The setup has been tested to ensure functionality.

### Areas for Review
- The configuration within the `Dockerfile` and `docker-compose.yaml` for any potential improvements.
- Integration and settings specified in `devcontainer.json`.

### Additional Context
N/A

### References
N/A