### PR TITLE
docs: Add license information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # general-template
 
 This is a versatile template, independent of any specific language or framework. Its purpose is to streamline the initial configuration of the repository and standardize its format. It can be utilized by designating it as a template during the creation of a new repository.
+
+## License
+
+Unless otherwise noted, the configure scripts and workflows included in this template are licensed under [The Unlicense](LICENSE_Unlicense.md). Other configuration files and documents are licensed under [CC0-1.0](LICENSE_CC0-1_0.md). Both licenses effectively place the work in the public domain, allowing for free replication, modification, distribution, and use, even for commercial purposes, without needing permission.
+
+This template repository is designed to be freely and easily modifiable to suit various needs. By applying these licenses, we ensure that users can adapt and incorporate these resources into their projects without legal constraints, avoiding potential conflicts with the licenses of the repositories created using this template.
+
+When creating a repository using this template, it is recommended to promptly set a license appropriate for your repository. Selecting an appropriate license ensures clarity and legal protection for your project's usage and distribution.
+
+Please note that we cannot provide personalized legal advice on licensing matters.


### PR DESCRIPTION
### Summary
This pull request updates the `README.md` file to include comprehensive license information, addressing the requirements of Issue #16.

### Related Issues/PRs/Discussions
- Closes #16

### Background
The need to clarify the licensing details in the `README.md` file was identified as a crucial step towards ensuring legal integrity and transparency for users of the template. This update aims to provide clear information on the permissions and restrictions associated with the use of the template.

### Detailed Changes
- Added a "License" section to the `README.md` file.
- The section details the licensing of configuration scripts and workflows under The Unlicense and other documents under CC0-1.0.
- Included advice for users to set an appropriate license for their repositories when using the template.
- Added a disclaimer stating that personalized legal advice on licensing matters cannot be provided.

### Pre-Merge Checklist
- [x] Review the accuracy of the license information.
- [x] Ensure the links to the licenses are correctly formatted and functional.
- [x] Confirm that the language used is clear and accessible to non-legal experts.

### Testing
The changes were reviewed for accuracy and completeness. No automated tests were necessary, as the update is documentation-related.

### User Impact
This update provides users with clear and comprehensive information about the licensing of the template, enabling them to make informed decisions regarding its use.

### Risk Assessment
The changes are low risk as they pertain solely to documentation and do not affect the functionality of the template.

### Areas for Review
- Accuracy of the license information.
- Clarity and accessibility of the language used.

### Additional Context
N/A

### References
N/A