### PR TITLE
feat: Add .pnpm-store/ and node_modules/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ ehthumbs_vista.db
 .idea/**/.gitignore
 .idea/**/workspace.xml
 .idea/**/usage.statistics.xml
+
+## Node.js
+.pnpm-store/
+node_modules/


### PR DESCRIPTION
### Summary
This pull request adds the `.pnpm-store/` and `node_modules/` directories to the `.gitignore` file, addressing the requirements of Issue #33. This change is part of our ongoing efforts to integrate pnpm into our project, ensuring a cleaner repository by preventing these directories from being tracked by Git.

### Related Issues/PRs/Discussions
- Closes #33

### Background
Issue #33 highlighted the need to update our `.gitignore` to include `.pnpm-store/` and `node_modules/` as part of preparing for the integration of pnpm. This package manager is known for its efficiency and speed improvements over npm, making it a valuable addition to our project.

### Detailed Changes
- Updated the `.gitignore` file to include `.pnpm-store/` and `node_modules/`.

### Pre-Merge Checklist
- [x] Ensure the `.gitignore` update does not affect other project areas.

### Testing
Added files to both `.pnpm-store/` and `node_modules/` directories and ran `git status` to confirm that these files are not tracked by Git. This ensures that our repository remains clean and that unnecessary files are not included in our version control system.

### User Impact
This change does not directly impact end-users but significantly benefits developers by keeping the repository clean and ensuring efficient package management with pnpm.

### Risk Assessment
The changes are low risk as they only involve updates to the `.gitignore` file, preventing specific directories from being tracked by Git. These updates are fully tested to ensure no unintended consequences.

### Areas for Review
- Review the `.gitignore` file changes to ensure all necessary directories are included and no essential files are excluded.

### Additional Context
N/A

### References
- [pnpm official website](https://pnpm.io/)