### PR TITLE
chore: Add dedicated volumes for `node_modules/` and `.pnpm-store/` in Dev Container

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -9,3 +9,10 @@ services:
     stdin_open: true
     volumes:
       - ../:/workspace
+      # Isolating the node_modules and pnpm-store directories to avoid conflicts with the local environment.
+      - node_modules:/workspace/node_modules
+      - pnpm-store:/workspace/.pnpm-store
+
+volumes:
+  node_modules:
+  pnpm-store:

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -18,7 +18,9 @@ function restore_dependencies() {
 # @noargs
 # @description Docker volumes are created with root ownership. This function changes the ownership of the volumes to the current user.
 function change_volume_ownership() {
-	:
+
+	sudo chown -R "$(whoami)" ./node_modules
+	sudo chown -R "$(whoami)" ./.pnpm-store
 }
 
 # @brief Main function.


### PR DESCRIPTION
### Summary
This PR adds dedicated Docker volumes for `node_modules/` and `.pnpm-store/` within the Dev Container, ensuring isolation from the local environment and improving the consistency of the development setup.

### Related Issues/PRs/Discussions
- Closes #44

### Background
To enhance the isolation between the local development environment and the Dev Container, it was proposed to create dedicated volumes for `node_modules/` and `.pnpm-store/`. This approach prevents potential conflicts and ensures that dependencies are managed within the container scope.

### Detailed Changes
- Modified the `.devcontainer/compose.yaml` to define and mount volumes for `node_modules/` and `.pnpm-store/`.
- Updated the `.devcontainer/post_create.sh` script to change the ownership of these volumes to the current user, ensuring proper access rights.

### Pre-Merge Checklist
- [x] Ensure the `.devcontainer/compose.yaml` and `.devcontainer/post_create.sh` are updated.
- [x] Verify the volumes are correctly mounted and accessible within the Dev Container.

### Testing
Connected to the Dev Container and verified that the `node_modules/` and `.pnpm-store/` volumes are correctly mounted and writable, confirming the successful setup of the dedicated volumes.

### User Impact
Developers will benefit from a more isolated and consistent development environment, with reduced risk of conflicts between the local and containerized `node_modules/` and `.pnpm-store/`.

### Risk Assessment
The changes are confined to the Dev Container configuration, presenting minimal risk to the existing development workflow. The modifications have been tested to ensure they do not disrupt the container's functionality.

### Areas for Review
- Review the updates to the `.devcontainer/compose.yaml` and `.devcontainer/post_create.sh` for correctness and completeness.

### Additional Context
N/A

### References
- Docker volumes documentation: https://docs.docker.com/storage/volumes/
- pnpm documentation: https://pnpm.io/