### PR TITLE
feat: Create GitHub Actions Workflow to Ensure PRs Have Milestones

### DIFF
--- a/.github/workflows/pr-milestone_checker.yml
+++ b/.github/workflows/pr-milestone_checker.yml
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Unlicense
+
+# This workflow ensures that every Pull Request is assigned to a milestone. It triggers on pull request creation, reopening, and
+# milestone addition/removal events. If a milestone is not assigned, it throws an error and requests the assignee to assign one.
+
+name: PR Milestone Checker
+
+on:
+  pull_request:
+    types: [opened, reopened, milestoned, demilestoned]
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
+jobs:
+  check-milestone:
+    name: Check Milestone
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check milestone
+        run: |
+          if [[ -z "${{ github.event.pull_request.milestone }}" ]]; then
+            echo "::error::Pull Request is not assigned to a milestone."
+            exit 1
+          fi
+
+      - name: Write summary
+        if: failure()
+        run: |
+          echo "Please assign a milestone to the Pull Request." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
### Summary
Created a GitHub Actions Workflow to check if a Milestone is set for Pull Requests. This addresses issue #42.

### Related Issues/PRs/Discussions
- Closes #42

### Background
To ensure that every Pull Request is associated with a Milestone, a GitHub Actions Workflow was created. This helps in better tracking and management of project progress.

### Detailed Changes
- Added a GitHub Actions Workflow to check for Milestones in Pull Requests.
- The workflow triggers on pull request creation, reopening, and milestone addition/removal events.
- If a Milestone is not set, the workflow fails and requests the assignee to set one.

### Pre-Merge Checklist
- [ ] Ensure the workflow file is correctly placed in the `.github/workflows` directory.
- [ ] Verify that the workflow triggers on the specified pull request events.

### Testing
- Created the same workflow in a test repository.
- Created a PR without setting a Milestone and confirmed that the workflow failed.
- Set a Milestone on the PR and confirmed that the workflow succeeded.
- Created a new PR with a Milestone set and confirmed that the workflow succeeded.

### User Impact
This workflow ensures that all Pull Requests are associated with Milestones, improving project management and visibility.

### Risk Assessment
Minimal risk; the workflow only checks for the presence of a Milestone and does not affect other functionalities.

### Areas for Review
- Review the workflow file for correct syntax and event triggers.
- Ensure the error messages are clear and informative.

### Additional Context
N/A

### References
N/A