### PR TITLE
feat: Introduce Lefthook for Git Hooks Management

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Unlicense
+
+commit-msg:
+  commands:
+    "lint commit message":
+      # TODO: Add command to lint commit message
+      run: echo "Linting commit message"

--- a/package.json
+++ b/package.json
@@ -14,10 +14,8 @@
     "type": "git",
     "url": "https://github.com/ShohtaKouchi/general-template/.git"
   },
-  "scripts": {
-  },
-  "dependencies": {
-  },
+  "scripts": {},
   "devDependencies": {
+    "lefthook": "1.7.9"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,4 +6,91 @@ settings:
 
 importers:
 
-  .: {}
+  .:
+    devDependencies:
+      lefthook:
+        specifier: 1.7.9
+        version: 1.7.9
+
+packages:
+
+  lefthook-darwin-arm64@1.7.9:
+    resolution: {integrity: sha512-WF1ELaKKpU3qkoHAklg7/mI4fkd4hiGRV1DngLU+vz0BoD89nRlp60tJsSPq+/O35raXy41wLE3cGVmgbTHeOw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  lefthook-darwin-x64@1.7.9:
+    resolution: {integrity: sha512-yNKmuSmbRXHuL9NCjuKO9wAsDxlP8ELXV6aFEFbuf12Rk5nJjp+e5VuKRkYlYA9uqLnIsZR79c2+/i+PgtmyNg==}
+    cpu: [x64]
+    os: [darwin]
+
+  lefthook-freebsd-arm64@1.7.9:
+    resolution: {integrity: sha512-+ZF7jIG2hRJbd36TbPkpHyxjR0e6cvo66WsUYBJy6DJPK3EJpkdsGiMrvMSbSYLfgzfhR6nOXBr5vOpL2lfBFw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  lefthook-freebsd-x64@1.7.9:
+    resolution: {integrity: sha512-LhSLdkf0HRhfuVsJP24oizfB94noCyyNLUOd35ZVd4KpAbFU/71OBBKqosig4QO4kyyRDWNK20tTbzCb1XKQxA==}
+    cpu: [x64]
+    os: [freebsd]
+
+  lefthook-linux-arm64@1.7.9:
+    resolution: {integrity: sha512-Bt7DAFU2/2ws3/i95tKOffRM0yau2jsa4ksCskq8igmEBQ6iTvsK8ZUowtXaAavXYKh0EZb3uQ63iFz+NKypmQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  lefthook-linux-x64@1.7.9:
+    resolution: {integrity: sha512-xe4X4KBf48Nzypdg1EX2s2xqytbguIZC7eYXZPer1YUggVDbRMrdVBK7J0OAEqA4RbvE82pDjrKSopnlYlMYhw==}
+    cpu: [x64]
+    os: [linux]
+
+  lefthook-windows-arm64@1.7.9:
+    resolution: {integrity: sha512-PQdBx8Pj7IEda1ipRULw0V4tzMe38VcbxVSUICxvHsG0levkfGA0GgjuftEryx4qDhVRE7VUzKuC9Qn1SSMuFw==}
+    cpu: [arm64]
+    os: [win32]
+
+  lefthook-windows-x64@1.7.9:
+    resolution: {integrity: sha512-lUMYgP9SUYrfoBGCfWNj7k9n8Nhwi83rAP0eLUvaHZFW7J/wCM4Pv9K85OkRMb7ToFRJIQ0zdD6Vdb6AZpeMVA==}
+    cpu: [x64]
+    os: [win32]
+
+  lefthook@1.7.9:
+    resolution: {integrity: sha512-/C8By2tUk/fHgLd1iH1elSPsYO75/hdNhyJvvQzLNtZ2IH7x3mC5a1pf1Zijpj+QD2vhRyz5W5sr9DShKvEagA==}
+    hasBin: true
+
+snapshots:
+
+  lefthook-darwin-arm64@1.7.9:
+    optional: true
+
+  lefthook-darwin-x64@1.7.9:
+    optional: true
+
+  lefthook-freebsd-arm64@1.7.9:
+    optional: true
+
+  lefthook-freebsd-x64@1.7.9:
+    optional: true
+
+  lefthook-linux-arm64@1.7.9:
+    optional: true
+
+  lefthook-linux-x64@1.7.9:
+    optional: true
+
+  lefthook-windows-arm64@1.7.9:
+    optional: true
+
+  lefthook-windows-x64@1.7.9:
+    optional: true
+
+  lefthook@1.7.9:
+    optionalDependencies:
+      lefthook-darwin-arm64: 1.7.9
+      lefthook-darwin-x64: 1.7.9
+      lefthook-freebsd-arm64: 1.7.9
+      lefthook-freebsd-x64: 1.7.9
+      lefthook-linux-arm64: 1.7.9
+      lefthook-linux-x64: 1.7.9
+      lefthook-windows-arm64: 1.7.9
+      lefthook-windows-x64: 1.7.9


### PR DESCRIPTION
### Summary
Introduce Lefthook for Pre-commit Hooks Management

### Related Issues/PRs/Discussions
- Closes #50

### Background
Lefthook has been introduced to manage pre-commit hooks efficiently. The specific scripts to be run by Lefthook will be determined and configured in a subsequent task. Currently, a placeholder for the `commit-msg` hook has been created in `.lefthook.yml`.

### Detailed Changes
- Installed Lefthook as a dev dependency.
- Created a basic `.lefthook.yml` configuration file with a placeholder for the `commit-msg` hook.

### Pre-Merge Checklist
N/A

### Testing
Tested locally by making a commit on the branch and verifying that the `commit-msg` hook is executed.

### User Impact
This change will help in managing pre-commit hooks more efficiently, ensuring code quality and consistency.

### Risk Assessment
Minimal risk; the changes are supplementary and tested for compatibility with existing features.

### Areas for Review
- Review the basic configuration of Lefthook in `.lefthook.yml`.

### Additional Context
N/A

### References
N/A