### PR TITLE
feat: Configure commitlint to Run with Lefthook

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -3,5 +3,4 @@
 commit-msg:
   commands:
     "lint commit message":
-      # TODO: Add command to lint commit message
-      run: echo "Linting commit message"
+      run: pnpm commitlint --edit "$1"


### PR DESCRIPTION
### Summary
Configured Lefthook to run commitlint for commit message linting.

### Related Issues/PRs/Discussions
- Closes #62

### Background
To enforce consistent commit message conventions automatically during the commit process, improving code quality and collaboration.

### Detailed Changes
- Updated Lefthook configuration to include commitlint as a pre-commit hook.

### Pre-Merge Checklist
N/A

### Testing
Tested locally by making commits on a local branch and confirmed that commitlint is executed.

### User Impact
This change will ensure that all commit messages adhere to the defined commitlint rules, improving consistency and readability.

### Risk Assessment
Minimal risk; the change only affects the commit process and has been tested locally.

### Areas for Review
- Review the Lefthook configuration for correctness.
- Ensure that commitlint rules are properly enforced.

### Additional Context
N/A

### References
N/A