### PR TITLE
feat: Install yamllint in Dev Container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && apt-get install -y  --no-install-recommends \
     python3-pip=23.0.* \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
+# Install yamllint.
+RUN pip install --no-cache-dir --break-system-packages yamllint==1.35.1
 RUN npm install -g pnpm@9.5
 
 # Install hadolint

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,6 +11,7 @@ RUN nodejs_setup=$(mktemp) && curl -fsSL -o $nodejs_setup https://deb.nodesource
     && rm $nodejs_setup
 RUN apt-get update && apt-get install -y  --no-install-recommends \
     nodejs=22.4.* \
+    python3-pip=23.0.* \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
### Summary
Installed `yamllint` in the Dev Container.

### Related Issues/PRs/Discussions
- Closes #67

### Background
To ensure YAML files are linted within the Dev Container, improving code quality and consistency.

### Detailed Changes
- Installed `yamllint` in the Dev Container.
- Installed `python3-pip` to install `yamllint`.

### Pre-Merge Checklist
N/A

### Testing
Started the Dev Container and verified the installation by running `yamllint -v`.

### User Impact
N/A

### Risk Assessment
Minimal risk; the installation process is straightforward and does not affect the existing codebase.

### Areas for Review
N/A

### Additional Context
N/A

### References
N/A